### PR TITLE
Create output directory automatically on update

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,40 @@ unused_strings:
 Once you are sure you will not use these strings anaymore, you can remove them from the yaml files. 
 You are encouraged to clean up these files before releasing a new version of your application.
 
+## How to test a Widget which uses i18n_omatic
+
+ You can use [Mockito package](https://pub.dev/packages/mockito) to mock the translation function `tr()` :
+
+ ```dart
+import 'package:i18n_omatic/i18n_omatic.dart';
+import 'package:mockito/mockito.dart';
+
+class MockI18nOMatic extends Mock implements I18nOMatic {}
+
+class MockSetUp {
+  static void mockI18nOMatic() {
+    I18nOMatic.instance = MockI18nOMatic();
+    when(I18nOMatic.instance.tr(any, any)).thenAnswer((realInvocation) {
+      var strTranslated = realInvocation.positionalArguments[0].toString();
+      if (realInvocation.positionalArguments[1] != null) {
+        realInvocation.positionalArguments[1].forEach((String key, String value) {
+          value ??= '';
+          strTranslated = strTranslated.replaceAll('%$key', value.toString());
+        });
+      }
+      return strTranslated;
+    });
+  }
+}
+```
+and call `MockSetUp.mockI18nOMatic()` at the Flutter Widget test beginning :
+```dart
+void main() {
+  setUp(()  {
+    MockSetUp.mockI18nOMatic();
+  });
+  [...]
+```
 
 ## Known limitations
 

--- a/bin/update.dart
+++ b/bin/update.dart
@@ -1,5 +1,7 @@
 import 'package:args/args.dart';
 
+import 'dart:io';
+
 import 'package:i18n_omatic/src/i18n_omatic_generator.dart';
 
 void main(List<String> args) {
@@ -35,9 +37,11 @@ void main(List<String> args) {
     if (parsedArgs['help']) {
       print(parser.usage);
     } else {
-      var gen =
-          I18nOMaticGenerator(parsedArgs['src-dir'], parsedArgs['out-dir']);
-      gen.run();
+      Directory(parsedArgs['out-dir']).create(recursive: true).then((e) {
+        var gen =
+            I18nOMaticGenerator(parsedArgs['src-dir'], parsedArgs['out-dir']);
+        gen.run();
+      });
     }
   }
 }


### PR DESCRIPTION
On update script : This change create automatically the output directory if not exists. 

Currently, the PR only create the main folder (by default: assets/i18nomatic) and not the yaml translation files. It will be interesting, if yaml translation files were created automatically, maybe by adding a configuration in pubspec.yaml to list all translations.