### PR TITLE
Add an output sort option

### DIFF
--- a/bin/update.dart
+++ b/bin/update.dart
@@ -18,6 +18,11 @@ void main(List<String> args) {
       help: 'path to translations files directory',
     )
     ..addFlag(
+      'sort',
+      negatable: false,
+      help: 'sort output',
+    )
+    ..addFlag(
       'help',
       negatable: false,
       help: 'displays this help message',
@@ -38,8 +43,11 @@ void main(List<String> args) {
       print(parser.usage);
     } else {
       Directory(parsedArgs['out-dir']).create(recursive: true).then((e) {
-        var gen =
-            I18nOMaticGenerator(parsedArgs['src-dir'], parsedArgs['out-dir']);
+        var gen = I18nOMaticGenerator(
+          parsedArgs['src-dir'],
+          parsedArgs['out-dir'],
+          parsedArgs['sort'],
+        );
         gen.run();
       });
     }

--- a/lib/src/i18n_omatic_generator.dart
+++ b/lib/src/i18n_omatic_generator.dart
@@ -13,15 +13,18 @@ class I18nOMaticGenerator {
 
   String? _outDir = '';
 
+  bool _sortOutput = false;
+
   final List<String> _srcFiles = <String>[];
 
   final List<String> _foundStrings = <String>[];
 
   final Map<String?, String> _translationsFiles = <String?, String>{};
 
-  I18nOMaticGenerator(String? srcDir, String? outDir) {
+  I18nOMaticGenerator(String? srcDir, String? outDir, bool sortOutput) {
     _srcDir = srcDir;
     _outDir = outDir;
+    _sortOutput = sortOutput;
   }
 
   List<String> get foundStrings {
@@ -117,6 +120,20 @@ class I18nOMaticGenerator {
         i18nData.existingStrings[value] = null;
       }
     });
+
+    if (_sortOutput) {
+      i18nData.existingStrings = Map.fromEntries(
+        i18nData.existingStrings.entries.toList()
+          ..sort(
+            (e1, e2) {
+              if (e1.value.runtimeType != e2.value.runtimeType) {
+                return e1.value == null ? 1 : -1;
+              }
+              return e1.key.compareTo(e2.key);
+            },
+          ),
+      );
+    }
 
     print(
         'Writing ${i18nData.existingStrings.length} existing strings and ${i18nData.unusedStrings.length} unused strings in translations file');

--- a/test/i18n_omatic_generator_test.dart
+++ b/test/i18n_omatic_generator_test.dart
@@ -27,8 +27,8 @@ void deployResources(String globExpr, String destPath) {
 }
 
 void main() {
-  var testGen =
-      I18nOMaticGenerator('test/_exec/lib', 'test/_exec/assets/i18nomatic');
+  var testGen = I18nOMaticGenerator(
+      'test/_exec/lib', 'test/_exec/assets/i18nomatic', false);
 
   setUpAll(() {
     recreateDir('test/_exec/lib');


### PR DESCRIPTION
Add a flag `sort` on generate translations script to sort generated translations string by :
- Null value at the end of file
- Alphabetically

To use the flag, just need to call : `dart run i18n_omatic:update --sort`